### PR TITLE
add sample modules for reference

### DIFF
--- a/facets_mcp/tools/instructions.py
+++ b/facets_mcp/tools/instructions.py
@@ -13,10 +13,10 @@ def FIRST_STEP_get_instructions() -> str:
     """
     <important>ALWAYS Call this tool first before calling any other tool of this mcp.</important>
     Loads all module writing instructions for Facets module development found in the
-    `module_instructions` directory.
-    
+    `module_instructions` directory and loads all sample terraform module files to enhance the knowledge base.
+
     Returns:
-        str: A JSON string containing the content of all instruction files, 
+        str: A JSON string containing the content of all instruction files,
               with each file's content stored under its filename as key.
     """
     instructions = {}
@@ -34,4 +34,36 @@ def FIRST_STEP_get_instructions() -> str:
     except FileNotFoundError as e:
         return json.dumps({"error": str(e)})
 
+    # Add sample modules context
+    instructions["sample_modules"] = load_sample_modules_context()
     return json.dumps(instructions, indent=2)
+
+
+def load_sample_modules_context() -> dict:
+    """
+    Loads sample module files (facets.yaml, variables.tf, main.tf, outputs.tf) from the modules directory
+    for reference in module generation.
+    Returns:
+        dict: {module_path: {file_name: file_content, ...}, ...}
+    """
+    modules_dir = os.path.join(os.path.dirname(__file__), "modules")
+    sample_context = {}
+    for root, dirs, files in os.walk(modules_dir):
+        module_files = {}
+        for fname in [
+            "facets.yaml",
+            "variables.tf",
+            "main.tf",
+            "outputs.tf",
+            "README.md",
+            "locals.tf",
+        ]:
+            fpath = os.path.join(root, fname)
+            if os.path.isfile(fpath):
+                with open(fpath, "r") as f:
+                    module_files[fname] = f.read()
+        if module_files:
+            # Use relative path from modules_dir as key
+            rel_path = os.path.relpath(root, modules_dir)
+            sample_context[rel_path] = module_files
+    return sample_context

--- a/facets_mcp/tools/module_instructions/facets_yaml_spec_x-ui_tags.md
+++ b/facets_mcp/tools/module_instructions/facets_yaml_spec_x-ui_tags.md
@@ -11,6 +11,12 @@ x-ui-output-type: "@output/kubernetes_service"  # Select from modules exporting 
 ```
 
 ```yaml
+x-ui-output:
+  field: attributes.subnet_id # Select a specific attribute from module
+  type: "@outputs/network" # Use this output type to derive the value of feild from another module
+```
+
+```yaml
 x-ui-secret-ref: true  # Reference a secret defined at the project level. Use this when a field has to be secret
 ```
 
@@ -44,7 +50,7 @@ x-ui-toggle: true  # Render this field group as collapsible. Use this to keep th
 ```
 
 ```yaml
-x-ui-yaml-editor: true  # Use YAML editor for complex object input. Use this when you want to surface a yaml editor, use this for complex objects only
+x-ui-yaml-editor: true  # Use YAML editor for complex object input expect in YAML format only. Use this when you want to surface a yaml editor, use this for complex objects only
 ```
 DONT OVERUSE THIS FIELD, WE WOULD LIKE TO KNOW SCHEMA AS MUCH AS POSSIBLE
 ---
@@ -52,8 +58,9 @@ DONT OVERUSE THIS FIELD, WE WOULD LIKE TO KNOW SCHEMA AS MUCH AS POSSIBLE
 ### ❗ Validation & Conditional Display
 
 ```yaml
-x-ui-error-message: "CIDR must be a valid private IP block"  # Custom error for validation failure
+x-ui-error-message: "CIDR must be a valid private IP block"  # Custom error for validation failure 
 ```
+USE THE ABOVE FIELD WHENEVER PATTERN IS DEFINED FOR TYPE STRING FEILDS
 
 ```yaml
 x-ui-visible-if:

--- a/facets_mcp/tools/module_instructions/tf.md
+++ b/facets_mcp/tools/module_instructions/tf.md
@@ -14,7 +14,7 @@ Every Facets module automatically receives the following variables:
 - `environment`: An object with environment-specific metadata:
   - `name`: Logical environment name.
   - `unique_name`: Globally unique environment identifier.
-  - `cloud_tags`: Standard tags applied to all resources for control plane traceability.
+  - `cloud_tags`: Standard tags applied to all resources for control plane traceability. Always merge this tags with user supplied tags wherever applicable.
 
 These are injected automatically and do not need to be declared manually.
 
@@ -35,6 +35,7 @@ Terraform logic in `main.tf` must only use:
 ### Rules & Restrictions
 
 - Do **not** define `provider` blocks. Providers must be injected through inputs.
+- Always add `resourceName` and `resourceType` tags/labels wherever applicable. Value of `resourceType` will **always** be the intent defined in facets.yaml and `resourceName` will be value of instance_name terraform variable.
 - Do **not** define `output` blocks. Use `locals.output_attributes` to expose values.
 - Reference only variables defined in `variables.tf`.
 - Always derive names from `instance_name` and `environment.unique_name` unless specified by user.

--- a/facets_mcp/tools/module_instructions/variables.md
+++ b/facets_mcp/tools/module_instructions/variables.md
@@ -31,7 +31,7 @@ Defines inputs that developers can configure when using the module.
 - `description`
 - `default`
 - `enum`
-- `pattern`
+- `pattern` (use this to define regex wherever applicable)
 - `minimum`, `maximum`
 - `minLength`, `maxLength`
 

--- a/facets_mcp/tools/modules/cloud_account/aws/1.0/README.md
+++ b/facets_mcp/tools/modules/cloud_account/aws/1.0/README.md
@@ -1,0 +1,27 @@
+# Cloud Account Module
+
+This module provides a way to use a specific cloud account for creating resources using terraform on AWS. This module also allows users to use custom aws providers in facets cloud by exposing type `@outputs/cloud_account`.
+
+## Functionality
+
+- Provides a way to use a specific AWS cloud account credentials so that it can be used by terraform to create cloud resources.
+- Also provides user ability to use custom terraform providers if required.
+
+
+## Configurability
+
+| Name              | Description                                          | Type   | Default | Required |
+| ----------------- | ---------------------------------------------------- | ------ | ------- | -------- |
+| region            | AWS region to use for the provider                   | string | n/a     | no       |
+| role_arn          | ARN of the role to assume for provider configuration | string | n/a     | yes      |
+| role_session_name | Identifier for the assumed role session              | string | n/a     | yes      |
+| external_id       | External ID for cross-account role assumption        | string | n/a     | yes      |
+
+## Outputs
+
+| Name         | Description                                                  |
+| ------------ | ------------------------------------------------------------ |
+| aws_iam_role | The ARN of the assumed role                                  |
+| session_name | The identifier for the assumed role session.                 |
+| external_id  | The identifier required to assume a role in another account. |
+| aws_region   | The AWS Region configured for Terraform AWS Provider         |

--- a/facets_mcp/tools/modules/cloud_account/aws/1.0/facets.yaml
+++ b/facets_mcp/tools/modules/cloud_account/aws/1.0/facets.yaml
@@ -1,0 +1,78 @@
+intent: cloud_account
+flavor: aws
+version: "1.0"
+clouds: [ aws ]
+description: A cloud account is a user account used to access and manage services provided by a cloud computing service provider.
+spec:
+  title: Cloud Account
+  description: Specifications of AWS cloud account.
+  type: object
+  properties:
+    region:
+      title: Region
+      description: Geographically distinct location with one or more data centers. Determine where the data is stored and where computing resources will run.
+      type: string
+      x-ui-placeholder: "Eg: us-east-1" # placeholder for the region
+      x-ui-overrides-only: true # Show only when overriding per environment.
+    role_arn:
+      title: Role ARN
+      description: The Amazon Resource Name (ARN) of the role to assume.
+      type: string
+      pattern: "^arn:aws:iam::[0-9]{12}:role/[\\w+=,.@-]$+" # regex pattern for role ARN
+      x-ui-placeholder: "Eg: arn:aws:iam::123456789012:role/role_name" # placeholder for the role ARN
+      x-ui-error-message: "Value did not match pattern \"^arn:aws:iam::[0-9]{12}:role/[\\w+=,.@-]$+\". Eg: arn:aws:iam::123456789012:role/role_name"
+      x-ui-override-disable: true # disables the override option in UI
+    role_session_name:
+      title: Role Session Name
+      description: The identifier for the assumed role session. Used to to uniquely identify a session when the same role is assumed by different principals or for different reasons.
+      type: string
+      pattern: "^[\\w+=,.@-]+$" # regex pattern for role session name
+      minLength: 2 # minimum length for role session name
+      maxLength: 27 # maximum length for role session name
+      x-ui-placeholder: "Eg: session_name" # placeholder for the role session name
+      x-ui-error-message: "Value did not match pattern \"^[\\w+=,.@-]+$\" or length must be >=2 and <=27 characters. Eg: session_name"
+      x-ui-override-disable: true # disables the override option in UI
+    external_id:
+      title: External Id
+      description: The unique identifier required to assume a role in another account.
+      type: string
+      pattern: "^[\\w+=,.@-]+$" # regex pattern for external id
+      minLength: 2 # minimum length for external id
+      maxLength: 1224 # maximum length for external id
+      x-ui-placeholder: "Eg: external_id" # placeholder for the external id
+      x-ui-error-message: "Value did not match pattern \"^[\\w+=,.@-]+$\" or length must be >=2 and <=1224 characters. Eg: external_id"
+      x-ui-secret-ref: true
+      x-ui-typeable: true # allows the user to type in a value if not present in dropdown
+  required:
+  - region
+  - role_arn
+  - role_session_name
+  - external_id
+outputs:
+  default:
+    type: "@outputs/cloud_account"
+    providers:
+      aws:
+        # exposses aws 5.97.0 provider
+        source: hashicorp/aws
+        version: "= 5.97.0"
+        attributes:
+          region: attributes.aws_region
+          skip_region_validation: true
+          attributes:
+            assume_role:
+              role_arn: attributes.aws_iam_role
+              session_name: attributes.session_name
+              external_id: attributes.external_id
+sample:
+  kind: cloud_account
+  flavor: aws
+  version: "1.0"
+  disabled: true # always set this to true to disable the sample
+  spec:
+    type: object
+    properties:
+      region: "" # dont set any value as this is a sample
+      role_arn: ""
+      role_session_name: ""
+      external_id: ""

--- a/facets_mcp/tools/modules/cloud_account/aws/1.0/outputs.tf
+++ b/facets_mcp/tools/modules/cloud_account/aws/1.0/outputs.tf
@@ -1,0 +1,14 @@
+locals {
+  output_interfaces = {}
+  output_attributes = {
+    aws_iam_role = sensitive(var.instance.spec.role_arn)
+    session_name = sensitive("${var.instance.spec.role_session_name}-${uuid()}")
+    external_id  = sensitive(var.instance.spec.external_id)
+    aws_region   = var.instance.spec.region
+    secrets = [
+      "aws_iam_role",
+      "session_name",
+      "external_id",
+    ]
+  }
+}

--- a/facets_mcp/tools/modules/cloud_account/aws/1.0/variables.tf
+++ b/facets_mcp/tools/modules/cloud_account/aws/1.0/variables.tf
@@ -1,0 +1,29 @@
+variable "instance" {
+  description = "A cloud account is a user account used to access and manage services provided by a cloud computing service provider."
+  type = object({
+    kind    = string,
+    flavor  = string,
+    version = string,
+    spec = object({
+      role_arn          = string,
+      role_session_name = string,
+      external_id       = string,
+      region            = string,
+    }),
+  })
+}
+variable "instance_name" {
+  description = "The architectural name for the resource as added in the Facets blueprint designer."
+  type        = string
+}
+variable "environment" {
+  description = "An object containing details about the environment."
+  type = object({
+    name        = string,
+    unique_name = string,
+  })
+}
+variable "inputs" {
+  description = "A map of inputs requested by the module developer."
+  type        = object({})
+}

--- a/facets_mcp/tools/modules/cloud_compute/aws_ec2/1.0/README.md
+++ b/facets_mcp/tools/modules/cloud_compute/aws_ec2/1.0/README.md
@@ -1,0 +1,131 @@
+# AWS EC2 Module
+
+This module provisions an AWS EC2 instance with comprehensive configuration options for compute, storage, networking, IAM, and security.
+
+## Overview
+
+The AWS EC2 module creates a highly configurable compute instance, along with all necessary supporting resources:
+
+- EC2 instance with customizable instance type and AMI
+- Root volume with required size and type specification
+- Optional additional EBS volumes with explicit configuration
+- IAM role and instance profile (existing or new)
+- Custom security groups with flexible ingress and egress rules
+- SSH key pair (generated or existing)
+- Custom tags with key-value pairs
+- Instance tagging and metadata
+
+## Environment as Dimension
+
+This module adapts to different environments by:
+
+- Creating unique resource names using environment identifiers
+- Applying environment-specific tags to all resources
+- Supporting environment-specific security group rules
+- Allowing custom user data scripts that can adapt to environments
+
+## Resources Created
+
+- **AWS EC2 Instance**: The main compute resource
+- **Security Group**: Controls network access to the instance
+- **SSH Key Pair**: Generated (if not specified) for SSH access
+- **EBS Volumes**: Root volume and optional additional volumes
+- **Volume Attachments**: For connecting additional volumes
+- **IAM Role** (Optional): For instance permissions
+- **IAM Policy** (Optional): Custom policy for the instance
+- **IAM Instance Profile** (Optional): For attaching role to instance
+
+## Security Considerations
+
+- Root and additional EBS volumes are encrypted by default
+- SSH access is always enabled on port 22 by default for security management
+- Security group rules are fully customizable (except for SSH on port 22)
+- IAM instance profile can be configured with least privilege
+- Custom SSH key pair can be specified
+
+## Configurability
+
+This module supports extensive customization, including:
+
+### Compute Configuration
+- **Instance Type**: EC2 instance type (t3.micro, m5.large, etc.) - Required
+- **AMI ID**: Custom AMI or default Amazon Linux 2
+- **Root Volume**:
+  - **Size**: Size in GB (8-16384) - Required
+  - **Type**: Volume type (gp2, gp3, io1, etc.) - Required
+- **Additional EBS Volumes**: Optional data volumes with explicit configuration:
+  - **Device Name**: The device path - Required when enabled
+  - **Size**: Volume size in GB - Required when enabled
+  - **Type**: Volume type - Required when enabled
+  - **Encryption**: Enable/disable encryption (default: true)
+
+### IAM Configuration
+- **Instance Profile Options**:
+  - Use no instance profile
+  - Use an existing instance profile by name
+  - Create a new instance profile with IAM role and custom policy
+- **Policy Document**: JSON policy to attach to the IAM role
+
+### Security Group Configuration
+- **SSH Access**: (Always enabled for port 22)
+  - Configure source CIDR blocks for SSH (default: 0.0.0.0/0)
+  - Specify existing key pair or generate new one
+- **Custom Ingress Rules**:
+  - Define additional ingress rules with ports, protocols, and CIDR blocks
+  - Support for TCP, UDP, ICMP, and all traffic (-1)
+  - Note: SSH on port 22 is always configured separately and doesn't need to be included in custom rules
+- **Custom Egress Rules**:
+  - Restrict default "allow all" egress if needed
+  - Define custom egress rules to specific destinations
+
+### Networking and Instance Configuration
+- **Public IP Association**: Enable/disable public IP assignment
+- **Detailed Monitoring**: Enable/disable enhanced CloudWatch monitoring
+- **Custom Hostname**: Set instance hostname
+- **User Data Script**: Custom initialization script
+
+### Tagging Configuration
+- **Custom Tags**: Define any number of custom tags with key-value pairs
+  - Example:
+    ```
+    tags:
+      tag1:
+        key: environment
+        value: "production"
+      tag2:
+        key: app
+        value: "myapp"
+      custom_tag:
+        key: owner
+        value: "team-name"
+    ```
+
+## AWS Architecture Notes
+
+This module follows AWS architectural best practices:
+
+1. **Storage Configuration**:
+   - Root volume size and type are required fields to ensure explicit configuration
+   - Additional volume parameters are required when enabled
+   - All volumes are encrypted by default for security
+
+2. **IAM Role and Instance Profile Relationship**:
+   - IAM roles contain permission policies
+   - Instance profiles are containers for IAM roles
+   - EC2 instances use instance profiles to assume IAM roles
+   - When creating a new instance profile, a corresponding IAM role is always created
+
+3. **Security Best Practices**:
+   - SSH access is always available for management but can be restricted to specific CIDR blocks
+   - Security group rules follow principle of least privilege by default
+
+## Outputs
+
+The module provides comprehensive outputs for integration with other systems:
+
+- **Instance**: ID, public/private IPs, hostname
+- **Network**: VPC ID, subnet ID
+- **SSH Access**: Connection details including private key (if generated)
+- **IAM**: Role name and instance profile (if created)
+- **Instance Details**: Type, volume info, security group ID
+- **Custom Tags**: All custom tags applied to the instance

--- a/facets_mcp/tools/modules/cloud_compute/aws_ec2/1.0/facets.yaml
+++ b/facets_mcp/tools/modules/cloud_compute/aws_ec2/1.0/facets.yaml
@@ -1,0 +1,312 @@
+intent: cloud_compute
+flavor: aws_ec2
+version: "1.0"
+clouds: [ aws ]
+description: A detailed AWS EC2 instance module that allows for comprehensive VM configuration including instance type, AMI, storage, networking, security groups, and more.
+spec:
+  title: AWS EC2 Detailed VM Configuration
+  description: A detailed AWS EC2 instance module that allows for comprehensive VM configuration including instance type, AMI, storage, networking, security groups, and more.
+  type: object
+  properties:
+    instance_type:
+      title: Instance Type
+      description: EC2 instance type to use for the VM (e.g., t3.micro, m5.large, c5.xlarge)
+      type: string
+      x-ui-placeholder: "e.g., t3.micro, m5.large, c5.xlarge"
+    ami_id:
+      title: AMI ID
+      description: The ID of the Amazon Machine Image to use. Leave blank to use the latest Amazon Linux 2 AMI.
+      type: string
+      pattern: "^(ami-[a-f0-9]{17})?$"
+      x-ui-error-message: "AMI ID must be in the format ami-xxxxxxxxxxxxxxxxx or left empty"
+      x-ui-placeholder: "e.g., ami-0c55b159cbfafe1f0"
+    root_volume_size:
+      title: Root Volume Size (GB)
+      description: Size of the root volume in GB
+      type: number
+      minimum: 8
+      maximum: 16384
+    root_volume_type:
+      title: Root Volume Type
+      description: Type of the root EBS volume
+      type: string
+      enum: ["gp2", "gp3", "io1", "io2", "sc1", "st1", "standard"]
+    associate_public_ip:
+      title: Associate Public IP
+      description: Associate a public IP address with the instance
+      type: boolean
+      default: true
+    enable_detailed_monitoring:
+      title: Enable Detailed Monitoring
+      description: Enable detailed CloudWatch monitoring (additional charges apply)
+      type: boolean
+      default: false
+    hostname:
+      title: Hostname
+      description: Custom hostname for the instance
+      type: string
+      x-ui-placeholder: "e.g., webserver-01"
+    user_data:
+      title: User Data
+      description: Custom user data script for instance initialization (bash script)
+      type: string
+      x-ui-placeholder: "#!/bin/bash\n# Add your bash script here"
+    additional_volumes:
+      title: Additional EBS Volumes
+      description: Additional EBS volumes to attach to the instance
+      type: object
+      x-ui-toggle: true
+      properties:
+        enabled:
+          title: Enable Additional Volumes
+          description: Enable or disable additional EBS volumes
+          type: boolean
+          default: false
+        volumes:
+          title: Volume Configurations
+          description: Configuration for additional volumes
+          type: object
+          x-ui-visible-if:
+            field: spec.additional_volumes.enabled
+            values: [true]
+          properties:
+            data_volume:
+              type: object
+              properties:
+                device_name:
+                  title: Device Name
+                  description: The device name (e.g., /dev/sdf, /dev/sdg)
+                  type: string
+                  pattern: "^/dev/sd[f-z]$"
+                  x-ui-error-message: "Device name must be in the format /dev/sd[f-z]"
+                size:
+                  title: Volume Size (GB)
+                  description: Size of the volume in GB
+                  type: number
+                  minimum: 1
+                  maximum: 16384
+                type:
+                  title: Volume Type
+                  description: Type of the EBS volume
+                  type: string
+                  enum: ["gp2", "gp3", "io1", "io2", "sc1", "st1", "standard"]
+                encrypted:
+                  title: Encrypt Volume
+                  description: Enable or disable volume encryption
+                  type: boolean
+                  default: true
+              required:
+                - device_name
+                - size
+                - type
+    iam:
+      title: IAM Configuration
+      description: IAM settings for the EC2 instance
+      type: object
+      x-ui-toggle: true
+      properties:
+        instance_profile_config:
+          title: Instance Profile Configuration
+          description: Configuration for the IAM instance profile
+          type: string
+          enum: ["none", "existing", "create_new"]
+          default: "none"
+        existing_instance_profile_name:
+          title: Existing Instance Profile Name
+          description: Name of an existing IAM instance profile to attach to the instance
+          type: string
+          x-ui-visible-if:
+            field: spec.iam.instance_profile_config
+            values: ["existing"]
+          x-ui-placeholder: "e.g., MyEC2InstanceProfile"
+        create_instance_profile:
+          title: New Instance Profile Configuration
+          description: Configuration for creating a new IAM role and instance profile
+          type: object
+          x-ui-visible-if:
+            field: spec.iam.instance_profile_config
+            values: ["create_new"]
+          properties:
+            policy_json:
+              title: Policy JSON
+              description: JSON policy document to attach to the IAM role (use {} for empty policy)
+              type: string
+              default: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"s3:ListAllMyBuckets\",\"Resource\":\"*\"}]}"
+    security_groups:
+      title: Security Group Configuration
+      description: Security settings for the EC2 instance
+      type: object
+      properties:
+        ssh_access:
+          title: SSH Access
+          description: "Configure SSH access to the instance (SSH on port 22 is always created for management)"
+          type: object
+          properties:
+            source_cidr:
+              title: Source CIDR Block 
+              description: CIDR block to allow SSH access from (e.g., 0.0.0.0/0 for anywhere, or your IP/32 for just your IP)
+              type: string
+              default: "0.0.0.0/0"
+              pattern: "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+              x-ui-error-message: "CIDR block must be in the format x.x.x.x/x"
+            key_name:
+              title: SSH Key Name
+              description: Name of an existing key pair to use for SSH access (leave blank to generate a new key pair)
+              type: string
+              x-ui-placeholder: "e.g., my-key-pair"
+        ingress_rules:
+          title: Custom Ingress Rules
+          description: "Additional custom security group ingress rules (Note: SSH on port 22 is already created - do not include it here)"
+          type: object
+          x-ui-toggle: true
+          properties:
+            rules:
+              title: Ingress Rules List
+              description: List of custom ingress rules
+              type: object
+              patternProperties:
+                "^[a-zA-Z0-9_-]+$":
+                  type: object
+                  properties:
+                    description:
+                      title: Description
+                      description: Description of the security rule
+                      type: string
+                    from_port:
+                      title: From Port
+                      description: Start port range
+                      type: number
+                      minimum: 0
+                      maximum: 65535
+                    to_port:
+                      title: To Port
+                      description: End port range
+                      type: number
+                      minimum: 0
+                      maximum: 65535
+                    protocol:
+                      title: Protocol
+                      description: Protocol (tcp, udp, icmp, or -1 for all)
+                      type: string
+                      enum: ["tcp", "udp", "icmp", "-1"]
+                      default: "tcp"
+                    cidr_blocks:
+                      title: CIDR Blocks
+                      description: CIDR block to allow access from (comma-separated)
+                      type: string
+                      pattern: "^(([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2})(,([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2})*$"
+                      x-ui-error-message: "CIDR blocks must be in the format x.x.x.x/x and comma-separated"
+                  required:
+                    - description
+                    - from_port
+                    - to_port
+                    - protocol
+                    - cidr_blocks
+        egress_rules:
+          title: Custom Egress Rules
+          description: Custom security group egress rules 
+          type: object
+          x-ui-toggle: true
+          properties:
+            restrict_default:
+              title: Restrict Default Egress
+              description: By default, all outbound traffic is allowed. Enable this to restrict outbound traffic.
+              type: boolean
+              default: false
+            rules:
+              title: Egress Rules List
+              description: List of custom egress rules
+              type: object
+              x-ui-visible-if:
+                field: spec.security_groups.egress_rules.restrict_default
+                values: [true]
+              patternProperties:
+                "^[a-zA-Z0-9_-]+$":
+                  type: object
+                  properties:
+                    description:
+                      title: Description
+                      description: Description of the security rule
+                      type: string
+                    from_port:
+                      title: From Port
+                      description: Start port range
+                      type: number
+                      minimum: 0
+                      maximum: 65535
+                    to_port:
+                      title: To Port
+                      description: End port range
+                      type: number
+                      minimum: 0
+                      maximum: 65535
+                    protocol:
+                      title: Protocol
+                      description: Protocol (tcp, udp, icmp, or -1 for all)
+                      type: string
+                      enum: ["tcp", "udp", "icmp", "-1"]
+                      default: "tcp"
+                    cidr_blocks:
+                      title: CIDR Blocks
+                      description: CIDR block to allow access to (comma-separated)
+                      type: string
+                      pattern: "^(([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2})(,([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2})*$"
+                      x-ui-error-message: "CIDR blocks must be in the format x.x.x.x/x and comma-separated"
+                  required:
+                    - description
+                    - from_port
+                    - to_port
+                    - protocol
+                    - cidr_blocks
+    tags:
+      title: Custom Tags
+      description: Custom tags to add to the EC2 instance (in addition to required Name, resourceType, and resourceName tags)
+      type: object
+      x-ui-toggle: true
+      patternProperties:
+        "^[a-zA-Z0-9_-]+$":
+          type: object
+          properties:
+            key:
+              title: Tag Key
+              description: Tag key name
+              type: string
+            value:
+              title: Tag Value
+              description: Tag value
+              type: string
+          required:
+            - key
+            - value
+  required:
+    - instance_type
+    - root_volume_size
+    - root_volume_type
+inputs:
+  cloud_account_details:
+    displayName: Cloud Account
+    description: The cloud account to be used for creating the compute instance.
+    optional: false
+    type: "@outputs/cloud_account"
+    providers:
+    - aws
+  network_details:
+    displayName: Network
+    description: The network to be used for creating the compute instance.
+    optional: false
+    type: "@outputs/network"
+outputs:
+  default:
+    type: "@outputs/cloud_compute"
+sample:
+  kind: cloud_compute
+  flavor: aws_ec2
+  version: "1.0"
+  disabled: true
+  spec:
+    type: object
+    properties:
+      instance_type: "t3.micro"
+      ami_id: ""
+      root_volume_size: 30
+      root_volume_type: "gp3"

--- a/facets_mcp/tools/modules/cloud_compute/aws_ec2/1.0/main.tf
+++ b/facets_mcp/tools/modules/cloud_compute/aws_ec2/1.0/main.tf
@@ -1,0 +1,270 @@
+locals {
+  // Default values and computed local variables
+  ssh_source_cidr = try(var.instance.spec.security_groups.ssh_access.source_cidr, "0.0.0.0/0")
+  ssh_key_name    = try(var.instance.spec.security_groups.ssh_access.key_name, "")
+  create_key_pair = local.ssh_key_name == ""
+  used_key_name   = local.create_key_pair ? "${var.instance_name}-${var.environment.unique_name}-key" : local.ssh_key_name
+
+  // Custom ingress and egress rules processing
+  ingress_rules   = try(var.instance.spec.security_groups.ingress_rules.rules, {})
+  restrict_egress = try(var.instance.spec.security_groups.egress_rules.restrict_default, false)
+  egress_rules    = try(var.instance.spec.security_groups.egress_rules.rules, {})
+
+  // IAM instance profile configuration
+  iam_config            = try(var.instance.spec.iam.instance_profile_config, "none")
+  use_existing_profile  = local.iam_config == "existing"
+  create_new_profile    = local.iam_config == "create_new"
+  existing_profile_name = try(var.instance.spec.iam.existing_instance_profile_name, "")
+
+  // Optional policy JSON parsing (default to empty policy if invalid JSON)
+  policy_json = try(local.create_new_profile ? jsondecode(var.instance.spec.iam.create_instance_profile.policy_json) : {}, {})
+  has_policy  = local.create_new_profile && length(local.policy_json) > 0
+
+  // The instance profile name to use for the EC2 instance
+  instance_profile_name = local.use_existing_profile ? local.existing_profile_name : (
+    local.create_new_profile ? aws_iam_instance_profile.instance_profile[0].name : null
+  )
+
+  // Process custom tags
+  custom_tags = try(var.instance.spec.tags, {})
+  processed_custom_tags = {
+    for tag_id, tag_obj in local.custom_tags :
+    tag_obj.key => tag_obj.value
+  }
+
+  // Merge tags for EC2 instance
+  instance_tags = merge(
+    var.environment.cloud_tags,
+    {
+      Name         = "${var.instance_name}-${var.environment.unique_name}-vm"
+      resourceType = "cloud_compute"
+      resourceName = var.instance_name
+    },
+    local.processed_custom_tags
+  )
+
+  // Hostname configuration
+  hostname = try(var.instance.spec.hostname, "") != "" ? var.instance.spec.hostname : "${var.instance_name}-${var.environment.unique_name}"
+
+  // Enable additional volume if configured
+  create_additional_volume = try(var.instance.spec.additional_volumes.enabled, false) && var.instance.spec.additional_volumes != null
+
+  // Additional volume parameters - using required fields directly
+  additional_volume_device_name = local.create_additional_volume ? var.instance.spec.additional_volumes.volumes.data_volume.device_name : null
+  additional_volume_size        = local.create_additional_volume ? var.instance.spec.additional_volumes.volumes.data_volume.size : null
+  additional_volume_type        = local.create_additional_volume ? var.instance.spec.additional_volumes.volumes.data_volume.type : null
+  additional_volume_encrypted   = local.create_additional_volume ? try(var.instance.spec.additional_volumes.volumes.data_volume.encrypted, true) : true
+}
+
+// Get latest Amazon Linux 2 AMI if no specific AMI is provided
+data "aws_ami" "default" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+// Create SSH key pair if not using an existing one and SSH is enabled
+resource "tls_private_key" "ssh_key" {
+  count     = local.create_key_pair ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "aws_key_pair" "deployer" {
+  count      = local.create_key_pair ? 1 : 0
+  key_name   = local.used_key_name
+  public_key = tls_private_key.ssh_key[0].public_key_openssh
+}
+
+// IAM role and instance profile creation if requested
+resource "aws_iam_role" "instance_role" {
+  count = local.create_new_profile ? 1 : 0
+  name  = "${var.instance_name}-${var.environment.unique_name}-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = merge(var.environment.cloud_tags, {
+    Name         = "${var.instance_name}-${var.environment.unique_name}-role"
+    resourceType = "cloud_compute"
+    resourceName = var.instance_name
+  })
+}
+
+resource "aws_iam_policy" "instance_policy" {
+  count       = local.has_policy ? 1 : 0
+  name        = "${var.instance_name}-${var.environment.unique_name}-policy"
+  description = "Policy for ${var.instance_name} EC2 instance"
+  policy      = var.instance.spec.iam.create_instance_profile.policy_json
+
+  tags = merge(var.environment.cloud_tags, {
+    Name         = "${var.instance_name}-${var.environment.unique_name}-policy"
+    resourceType = "cloud_compute"
+    resourceName = var.instance_name
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "policy_attachment" {
+  count      = local.has_policy ? 1 : 0
+  role       = aws_iam_role.instance_role[0].name
+  policy_arn = aws_iam_policy.instance_policy[0].arn
+}
+
+resource "aws_iam_instance_profile" "instance_profile" {
+  count = local.create_new_profile ? 1 : 0
+  name  = "${var.instance_name}-${var.environment.unique_name}-profile"
+  role  = aws_iam_role.instance_role[0].name
+}
+
+// Security group for EC2 instance
+resource "aws_security_group" "instance_sg" {
+  name        = "${var.instance_name}-${var.environment.unique_name}-sg"
+  description = "Security group for ${var.instance_name} EC2 instance"
+  vpc_id      = var.inputs.network_details.vpc_id
+
+  // SSH access is always enabled by default
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [local.ssh_source_cidr]
+    description = "SSH access"
+  }
+
+  // Custom ingress rules
+  dynamic "ingress" {
+    for_each = local.ingress_rules
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = split(",", ingress.value.cidr_blocks)
+      description = ingress.value.description
+    }
+  }
+
+  // Default egress rule if not restricted
+  dynamic "egress" {
+    for_each = local.restrict_egress ? [] : [1]
+    content {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "Allow all outbound traffic"
+    }
+  }
+
+  // Custom egress rules if restriction is enabled
+  dynamic "egress" {
+    for_each = local.restrict_egress ? local.egress_rules : {}
+    content {
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = split(",", egress.value.cidr_blocks)
+      description = egress.value.description
+    }
+  }
+
+  tags = merge(var.environment.cloud_tags, {
+    Name         = "${var.instance_name}-${var.environment.unique_name}-sg"
+    resourceType = "cloud_compute"
+    resourceName = var.instance_name
+  })
+}
+
+// Additional EBS volume if enabled
+resource "aws_ebs_volume" "additional_volume" {
+  count             = local.create_additional_volume ? 1 : 0
+  availability_zone = aws_instance.vm.availability_zone
+  size              = local.additional_volume_size
+  type              = local.additional_volume_type
+  encrypted         = local.additional_volume_encrypted
+
+  tags = merge(var.environment.cloud_tags, {
+    Name         = "${var.instance_name}-${var.environment.unique_name}-data-volume"
+    resourceType = "cloud_compute"
+    resourceName = var.instance_name
+  })
+}
+
+// Attach additional volume if enabled
+resource "aws_volume_attachment" "additional_volume_attachment" {
+  count       = local.create_additional_volume ? 1 : 0
+  device_name = local.additional_volume_device_name
+  volume_id   = aws_ebs_volume.additional_volume[0].id
+  instance_id = aws_instance.vm.id
+
+  # Force detach to avoid Terraform errors when rebuilding the instance
+  skip_destroy = false
+  force_detach = true
+}
+
+// EC2 instance
+resource "aws_instance" "vm" {
+  ami                    = var.instance.spec.ami_id != "" ? var.instance.spec.ami_id : data.aws_ami.default.id
+  instance_type          = var.instance.spec.instance_type
+  subnet_id              = var.inputs.network_details.subnet_id
+  vpc_security_group_ids = [aws_security_group.instance_sg.id]
+  key_name               = local.used_key_name
+
+  // IAM instance profile if enabled
+  iam_instance_profile = local.instance_profile_name
+
+  // Networking options
+  associate_public_ip_address = try(var.instance.spec.associate_public_ip, true)
+  monitoring                  = try(var.instance.spec.enable_detailed_monitoring, false)
+
+  // Hostname and user data configuration
+  user_data = try(var.instance.spec.user_data, "") != "" ? var.instance.spec.user_data : <<-EOF
+    #!/bin/bash
+    hostnamectl set-hostname ${local.hostname}
+    echo "127.0.0.1 ${local.hostname}" >> /etc/hosts
+  EOF
+
+  // Root volume configuration with required fields
+  root_block_device {
+    volume_size = var.instance.spec.root_volume_size
+    volume_type = var.instance.spec.root_volume_type
+    encrypted   = true
+    tags = merge(var.environment.cloud_tags, {
+      Name         = "${var.instance_name}-${var.environment.unique_name}-root-volume"
+      resourceType = "cloud_compute"
+      resourceName = var.instance_name
+    })
+  }
+
+  // Tags
+  tags = local.instance_tags
+
+  // Wait for the instance to be created before proceeding
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  // Make sure IAM resources are created before the instance
+  depends_on = [
+    aws_iam_instance_profile.instance_profile,
+    aws_iam_role_policy_attachment.policy_attachment
+  ]
+}

--- a/facets_mcp/tools/modules/cloud_compute/aws_ec2/1.0/outputs.tf
+++ b/facets_mcp/tools/modules/cloud_compute/aws_ec2/1.0/outputs.tf
@@ -1,0 +1,34 @@
+locals {
+  output_attributes = {
+    vpc_id      = var.inputs.network_details.vpc_id
+    subnet_id   = var.inputs.network_details.subnet_id
+    instance_id = aws_instance.vm.id
+    public_ip   = aws_instance.vm.public_ip
+    private_ip  = aws_instance.vm.private_ip
+    hostname    = local.hostname
+    custom_tags = local.processed_custom_tags
+    secrets     = ["ssh"]
+    ssh = {
+      host        = aws_instance.vm.public_ip
+      port        = 22
+      user        = "ec2-user"
+      public_key  = local.create_key_pair ? tls_private_key.ssh_key[0].public_key_openssh : null
+      private_key = local.create_key_pair ? sensitive(base64encode(tls_private_key.ssh_key[0].private_key_pem)) : null
+    }
+    instance_details = {
+      instance_type        = var.instance.spec.instance_type
+      root_volume_size     = var.instance.spec.root_volume_size
+      root_volume_type     = var.instance.spec.root_volume_type
+      security_group_id    = aws_security_group.instance_sg.id
+      iam_role             = local.create_new_profile ? aws_iam_role.instance_role[0].name : null
+      iam_enabled          = local.iam_config != "none"
+      ssh_enabled          = true
+      additional_volumes   = local.create_additional_volume
+      monitoring_enabled   = try(var.instance.spec.enable_detailed_monitoring, false)
+      iam_instance_profile = local.instance_profile_name
+      public_ip_associated = try(var.instance.spec.associate_public_ip, true)
+    }
+  }
+  output_interfaces = {
+  }
+}

--- a/facets_mcp/tools/modules/cloud_compute/aws_ec2/1.0/variables.tf
+++ b/facets_mcp/tools/modules/cloud_compute/aws_ec2/1.0/variables.tf
@@ -1,0 +1,110 @@
+variable "instance" {
+  description = "A detailed AWS EC2 instance module that allows for comprehensive VM configuration including instance type, AMI, storage, networking, security groups, and more."
+  type = object({
+    kind    = string
+    flavor  = string
+    version = string
+    spec = object({
+      instance_type              = string
+      ami_id                     = optional(string, "")
+      root_volume_size           = number
+      root_volume_type           = string
+      associate_public_ip        = optional(bool, true)
+      enable_detailed_monitoring = optional(bool, false)
+      hostname                   = optional(string, "")
+      user_data                  = optional(string, "")
+      additional_volumes = optional(object({
+        enabled = optional(bool, false)
+        volumes = optional(object({
+          data_volume = optional(object({
+            device_name = string
+            size        = number
+            type        = string
+            encrypted   = optional(bool, true)
+          }))
+        }))
+      }))
+      iam = optional(object({
+        instance_profile_config        = optional(string, "none")
+        existing_instance_profile_name = optional(string, "")
+        create_instance_profile = optional(object({
+          policy_json = optional(string, "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"s3:ListAllMyBuckets\",\"Resource\":\"*\"}]}")
+        }), {})
+      }), {})
+      security_groups = optional(object({
+        ssh_access = optional(object({
+          source_cidr = optional(string, "0.0.0.0/0")
+          key_name    = optional(string, "")
+        }), {})
+        ingress_rules = optional(object({
+          rules = optional(map(object({
+            description = string
+            from_port   = number
+            to_port     = number
+            protocol    = string
+            cidr_blocks = string
+          })), {})
+        }), {})
+        egress_rules = optional(object({
+          restrict_default = optional(bool, false)
+          rules = optional(map(object({
+            description = string
+            from_port   = number
+            to_port     = number
+            protocol    = string
+            cidr_blocks = string
+          })), {})
+        }), {})
+      }), {})
+      tags = optional(map(object({
+        key   = string
+        value = string
+      })), {})
+    })
+  })
+
+  validation {
+    condition     = can(regex("^(ami-[a-f0-9]{17})?$", var.instance.spec.ami_id))
+    error_message = "AMI ID must be in the format ami-xxxxxxxxxxxxxxxxx or left empty"
+  }
+
+  validation {
+    condition     = var.instance.spec.root_volume_size >= 8 && var.instance.spec.root_volume_size <= 16384
+    error_message = "Root volume size must be between 8 and 16384 GB"
+  }
+
+  validation {
+    condition     = contains(["gp2", "gp3", "io1", "io2", "sc1", "st1", "standard"], var.instance.spec.root_volume_type)
+    error_message = "Root volume type must be one of: gp2, gp3, io1, io2, sc1, st1, standard"
+  }
+
+  validation {
+    condition     = contains(["none", "existing", "create_new"], try(var.instance.spec.iam.instance_profile_config, "none"))
+    error_message = "IAM instance profile configuration must be one of: none, existing, create_new"
+  }
+}
+
+variable "instance_name" {
+  description = "The architectural name for the resource as added in the Facets blueprint designer."
+  type        = string
+}
+
+variable "environment" {
+  description = "An object containing details about the environment."
+  type = object({
+    name        = string
+    unique_name = string
+    cloud_tags  = map(string)
+  })
+}
+
+variable "inputs" {
+  description = "A map of inputs requested by the module developer."
+  type = object({
+    cloud_account_details = object({})
+    network_details = object({
+      vpc_id    = string
+      subnet_id = string
+    })
+  })
+}

--- a/facets_mcp/tools/modules/network/aws_vpc/1.0/README.md
+++ b/facets_mcp/tools/modules/network/aws_vpc/1.0/README.md
@@ -1,0 +1,21 @@
+# Network Module
+
+This module provisions an AWS Virtual Private Cloud (VPC) and subnet with configurable CIDR blocks. Requires `@outputs/cloud_account` type as input and uses custom providers exposed by it.
+
+## Functionality
+
+- Creates a VPC with a specified CIDR block.
+- Creates a subnet with in the VPC created as part of this module.
+
+## Configurability
+
+| Name     | Description                        | Type   | Default | Required |
+| -------- | ---------------------------------- | ------ | ------- | -------- |
+| vpc_cidr | CIDR block of mask /16 for the VPC | string | n/a     | yes      |
+
+## Outputs
+
+| Name      | Description                             |
+| --------- | --------------------------------------- |
+| vpc_id    | The ID of the created VPC               |
+| subnet_id | ID of the subnet created within the VPC |

--- a/facets_mcp/tools/modules/network/aws_vpc/1.0/facets.yaml
+++ b/facets_mcp/tools/modules/network/aws_vpc/1.0/facets.yaml
@@ -1,0 +1,41 @@
+intent: network
+flavor: aws_vpc
+version: "1.0"
+clouds: [ aws ]
+description: A Network is a way of communication between devices. Adds network of AWS VPC flavor.
+spec:
+  title: Network
+  description: Specifications for AWS VPC network.
+  type: object
+  properties:
+    vpc_cidr:
+      title: VPC CIDR
+      description: IPv4 CIDR block for the VPC. The CIDR block must be a valid IPv4 CIDR block and should have a mask of /16.
+      type: string
+      pattern: "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/16$"
+      x-ui-placeholder: "Eg: 10.0.0.0/16"
+      x-ui-error-message: "CIDR block must be a valid IPv4 CIDR block and should have a mask of /16."
+      x-ui-overrides-only: true  # Show only when overriding per environment as this changes per environment.
+      x-ui-override-disable: true # Disables the override option in UI as resource is created, changing this feild will cause the resource to be recreated.
+  required:
+  - vpc_cidr
+inputs:
+  cloud_account_details:
+    displayName: Cloud Account
+    description: The cloud account to be used for creating the network.
+    optional: false
+    type: "@outputs/cloud_account"
+    providers: # field to specify the provider to be used for creating the resources in the current terraform module
+    - aws # aws is the provider exposed by cloud_account module
+outputs:
+  default:
+    type: "@outputs/network"
+sample:
+  kind: network
+  flavor: aws_vpc
+  version: "1.0"
+  disabled: true
+  spec:
+    type: object
+    properties:
+      vpc_cidr: "" # dont set any value as this is a sample

--- a/facets_mcp/tools/modules/network/aws_vpc/1.0/main.tf
+++ b/facets_mcp/tools/modules/network/aws_vpc/1.0/main.tf
@@ -1,0 +1,23 @@
+locals {
+  subnet_cird = cidrsubnet(var.instance.spec.vpc_cidr, 4, 0)
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = var.instance.spec.vpc_cidr
+  tags = merge(var.environment.cloud_tags, {
+    Name         = "${var.instance_name}-vpc"
+    resourceType = "network"
+    resourceName = var.instance_name
+  })
+}
+
+resource "aws_subnet" "main" {
+  vpc_id     = aws_vpc.main.id
+  cidr_block = local.subnet_cird
+  tags = {
+    Name         = "${var.instance_name}-subnet"
+    resourceType = "network"
+    resourceName = var.instance_name
+  }
+  depends_on = [aws_vpc.main]
+}

--- a/facets_mcp/tools/modules/network/aws_vpc/1.0/outputs.tf
+++ b/facets_mcp/tools/modules/network/aws_vpc/1.0/outputs.tf
@@ -1,0 +1,7 @@
+locals {
+  output_interfaces = {}
+  output_attributes = {
+    vpc_id    = aws_vpc.main.id
+    subnet_id = aws_subnet.main.id
+  }
+}

--- a/facets_mcp/tools/modules/network/aws_vpc/1.0/variables.tf
+++ b/facets_mcp/tools/modules/network/aws_vpc/1.0/variables.tf
@@ -1,0 +1,29 @@
+variable "instance" {
+  description = "A Network is a way of communication between devices. Adds network of AWS VPC flavor."
+  type = object({
+    kind    = string,
+    flavor  = string,
+    version = string,
+    spec = object({
+      vpc_cidr = string,
+    }),
+  })
+}
+variable "instance_name" {
+  description = "The architectural name for the resource as added in the Facets blueprint designer."
+  type        = string
+}
+variable "environment" {
+  description = "An object containing details about the environment."
+  type = object({
+    name        = string,
+    unique_name = string,
+    cloud_tags  = map(string),
+  })
+}
+variable "inputs" {
+  description = "A map of inputs requested by the module developer."
+  type = object({
+    cloud_account_details = object({})
+  })
+}


### PR DESCRIPTION
This pr add sample terraform modules for MCP server to refer.

The following modules have been added:
- cloud_account aws
- network aws_vpc
- cloud_compute aws_ec2