### PR TITLE
FTF v0.2.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install dependencies
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "mcp[cli]",
     "checkov",
     "questionary",
-    "ftf-cli==v0.2.11",
+    "ftf-cli==0.2.11",
     "facets-control-plane-sdk",
 ]
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,15 +15,16 @@ dependencies = [
     "mcp[cli]",
     "checkov",
     "questionary",
-    "ftf-cli==v0.2.10",
+    "ftf-cli==v0.2.11",
     "facets-control-plane-sdk",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 keywords = ["Facets", "MCP", "Terraform", "Python"]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated minimum required Python version to 3.11.
  - Adjusted supported Python versions to include 3.12 and 3.13, and removed 3.10.
  - Upgraded the "ftf-cli" dependency to version 0.2.11.
  - Updated CI workflow to use Python 3.11 for publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->