### PR TITLE
set --skip-output-write as true with new ftf

### DIFF
--- a/facets_mcp/tools/ftf_tools.py
+++ b/facets_mcp/tools/ftf_tools.py
@@ -364,6 +364,9 @@ def push_preview_module_to_facets_cp(module_path: str, auto_create_intent: bool 
         command.extend(["-g", git_repo_url])
         command.extend(["-r", git_ref])
 
+        # do not update the output type - it should have already been created using register_output_type tool
+        command.extend(["--skip-output-write", "true"])
+
         message = run_ftf_command(command)
 
         return json.dumps({

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "mcp[cli]",
     "checkov",
     "questionary",
-    "ftf-cli==0.2.12",
+    "ftf-cli==0.3.0",
     "facets-control-plane-sdk==1.0.2",
 ]
 requires-python = ">=3.11"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for skipping output type updates during preview module pushes with a new command-line option.

* **Chores**
  * Updated the FTF CLI dependency to version 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->