### PR TITLE
added instruction to use lookup instead of try blocks

### DIFF
--- a/facets_mcp/tools/module_instructions/tf.md
+++ b/facets_mcp/tools/module_instructions/tf.md
@@ -38,3 +38,4 @@ Terraform logic in `main.tf` must only use:
 - Do **not** define `output` blocks. Use `locals.output_attributes` to expose values.
 - Reference only variables defined in `variables.tf`.
 - Always derive names from `instance_name` and `environment.unique_name` unless specified by user.
+- **Never** use `try()` blocks, **always** use `lookup()` with explicit default values.


### PR DESCRIPTION
Current MCP generates modules mainly with try() blocks. This causes issues during the plan/apply phases, as try blocks can only evaluate expressions with known values during planning causing for_each and if/else to break as they need known **values**