### PR TITLE
Update module_path docstring to specify absolute path requirement

### DIFF
--- a/facets_mcp/tools/module_files.py
+++ b/facets_mcp/tools/module_files.py
@@ -42,7 +42,7 @@ def list_files(module_path: str) -> str:
     Always ask User if he wants to add any variables or use any other FTF commands
 
     Args:
-        module_path (str): The path to the module directory.
+        module_path (str): The absolute path to the module directory.
 
     Returns:
         str: A JSON-formatted string with operation details and file list found in module directory.


### PR DESCRIPTION
## Summary
- Updated the docstring for the `module_path` parameter in the `list_files` function to clarify that it should be an absolute path to the module directory

## Test plan
- [x] Code change is documentation-only (docstring update)
- [x] No functional changes to existing behavior
- [x] Improved API documentation clarity

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified the list_files docstring: module_path is now described as the absolute path to the module directory, improving clarity for correct usage.
  - No functional changes; behavior and existing interfaces remain unchanged.
  - Aims to reduce ambiguity in parameter expectations for end-users reading inline documentation.
  - Estimated review effort is low; this is a documentation-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->