### PR TITLE
Fix float type error in module search functionality

### DIFF
--- a/facets_mcp/tools/existing_modules.py
+++ b/facets_mcp/tools/existing_modules.py
@@ -37,9 +37,9 @@ def fetch_modules(search_string: str = None):
         # Only filter if search_string is provided
         if search_string:
             if (
-                search_string in facets_content.get("intent", "")
-                or search_string in facets_content.get("flavor", "")
-                or search_string in facets_content.get("version", "")
+                search_string in str(facets_content.get("intent", ""))
+                or search_string in str(facets_content.get("flavor", ""))
+                or search_string in str(facets_content.get("version", ""))
             ):
                 modules.append(
                     {


### PR DESCRIPTION
Convert YAML values to strings before using 'in' operator to prevent "argument of type 'float' is not iterable" error when version or other fields contain numeric values instead of quoted strings.

🤖 Generated with [Claude Code](https://claude.ai/code)