### PR TITLE
inferred-from-module flag always true from mcp

### DIFF
--- a/facets_mcp/tools/ftf_tools.py
+++ b/facets_mcp/tools/ftf_tools.py
@@ -282,7 +282,12 @@ def register_output_type(
             temp_file_path = create_temp_yaml_file(output_type_def)
 
             # Build the command
-            command = ["ftf", "register-output-type", temp_file_path, "--inferred-from-module"]
+            command = [
+                "ftf",
+                "register-output-type",
+                temp_file_path,
+                "--inferred-from-module",
+            ]
 
             # Run the command
             result = run_ftf_command(command)

--- a/facets_mcp/tools/ftf_tools.py
+++ b/facets_mcp/tools/ftf_tools.py
@@ -282,7 +282,7 @@ def register_output_type(
             temp_file_path = create_temp_yaml_file(output_type_def)
 
             # Build the command
-            command = ["ftf", "register-output-type", temp_file_path]
+            command = ["ftf", "register-output-type", temp_file_path, "--inferred-from-module"]
 
             # Run the command
             result = run_ftf_command(command)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Output type registration now includes automatic module inference when invoking the registration CLI, reducing manual input and improving reliability. Existing workflows remain compatible with this convenience enhancement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->