### PR TITLE
Fix module count message to show accurate count when ≤10 modules

### DIFF
--- a/facets_mcp/tools/existing_modules.py
+++ b/facets_mcp/tools/existing_modules.py
@@ -89,10 +89,16 @@ def get_local_modules() -> str:
         limited_modules = modules[:10]
         instruction = "Inform User: For more modules, use the `find module` command to search for and work on a specific module."
 
+        # Create appropriate message based on whether we're showing all or limited results
+        if total_modules_count <= 10:
+            message = f"Found {total_modules_count} modules."
+        else:
+            message = f"Found {len(limited_modules)} modules (showing first 10 of {total_modules_count})."
+
         return json.dumps(
             {
                 "success": True,
-                "message": f"Found {len(limited_modules)} modules (showing first 10 of {total_modules_count}).",
+                "message": message,
                 "instructions": instruction,
                 "data": {
                     "modules": limited_modules,


### PR DESCRIPTION
Previously the message always showed "showing first 10 of X" even when there were fewer than 10 modules total. Now it shows "Found X modules." when there are 10 or fewer modules, and the original message when there are more than 10.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The module discovery message now adapts to the number of modules: for 10 or fewer, it shows the exact total; for larger sets, it indicates that only the first 10 are shown out of the total. This improves clarity, reduces confusion in small projects, and leaves all other responses and behaviors unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->