### PR TITLE
feat: Add module intent management and publishing tools

### DIFF
--- a/facets_mcp/tools/ftf_tools.py
+++ b/facets_mcp/tools/ftf_tools.py
@@ -158,7 +158,7 @@ def publish_module_to_facets_cp(
         # Build common args
         common_args = []
         if auto_create_intent:
-            common_args.extend(["-a", str(auto_create_intent)])
+            common_args.extend(["-a", "true"])
         # Always include git details
         common_args.extend(["-g", git_repo_url, "-r", git_ref])
         if skip_terraform_validation_if_provider_not_found:
@@ -591,9 +591,7 @@ def push_preview_module_to_facets_cp(
 
         command = ["ftf", "preview-module", module_path]
         if auto_create_intent:
-            command.extend(["-a", str(auto_create_intent)])
-        # Always mark previewed modules as publishable
-        command.extend(["-f", "true"])
+            command.extend(["-a", "true"])
         if skip_terraform_validation_if_provider_not_found:
             command.extend(["--skip-terraform-validation", "true"])
 

--- a/facets_mcp/tools/intent_management_tools.py
+++ b/facets_mcp/tools/intent_management_tools.py
@@ -259,7 +259,10 @@ def _read_module_intent(module_path: str) -> tuple[bool, str, str]:
     Internal: Read the module intent from facets.yaml.
     Returns (ok, intent, error_message)
     """
-    facets_path = os.path.join(os.path.abspath(module_path), "facets.yaml")
+    abs_path = os.path.abspath(module_path)
+    if not os.path.isdir(abs_path):
+        return False, "", f"Module path '{module_path}' is not a valid directory."
+    facets_path = os.path.join(abs_path, "facets.yaml")
     if not os.path.exists(facets_path):
         return False, "", "facets.yaml not found in module path."
     try:

--- a/facets_mcp/tools/intent_management_tools.py
+++ b/facets_mcp/tools/intent_management_tools.py
@@ -120,14 +120,16 @@ def create_or_update_intent(
         intent_api = IntentManagementApi(api_client)
 
         # Create the intent request DTO
-        intent_request = IntentRequestDTO(
-            name=name,
-            type=intent_type,
-            display_name=display_name,
-            description=description,
-            icon_url=icon_url,
-            inferred_from_module=False,
-        )
+        intent_kwargs = {
+            "name": name,
+            "type": intent_type,
+            "display_name": display_name,
+            "description": description,
+            "inferred_from_module": False,
+        }
+        if icon_url is not None:
+            intent_kwargs["icon_url"] = icon_url
+        intent_request = IntentRequestDTO(**intent_kwargs)
 
         # Create or update the intent using the correct API method
         try:
@@ -349,22 +351,24 @@ def map_module_to_project_type(
                 break
 
         # Prepare payload preserving existing values if not provided
-        payload = IntentRequestDTO(
-            name=intent,
-            type=project_type,
-            display_name=(
+        payload_kwargs = {
+            "name": intent,
+            "type": project_type,
+            "display_name": (
                 display_name
                 if display_name is not None
                 else getattr(existing, "display_name", intent)
             ),
-            description=(
+            "description": (
                 description
                 if description is not None
                 else getattr(existing, "description", f"Intent '{intent}'")
             ),
-            icon_url=icon_url,  # Only use explicitly provided icon_url
-            inferred_from_module=False,
-        )
+            "inferred_from_module": False,
+        }
+        if icon_url is not None:
+            payload_kwargs["icon_url"] = icon_url
+        payload = IntentRequestDTO(**payload_kwargs)
 
         response = intent_api.create_or_update_intent(payload)
         return json.dumps(

--- a/facets_mcp/tools/intent_management_tools.py
+++ b/facets_mcp/tools/intent_management_tools.py
@@ -6,8 +6,8 @@ Also includes helpers to map a local module's intent to a control-plane project 
 
 import json
 import os
-import yaml
 
+import yaml
 from swagger_client.api.intent_management_api import IntentManagementApi
 from swagger_client.models.intent_request_dto import IntentRequestDTO
 from swagger_client.rest import ApiException
@@ -271,9 +271,6 @@ def _read_module_intent(module_path: str) -> tuple[bool, str, str]:
         return False, "", f"Error reading facets.yaml: {e!s}"
 
 
- 
-
-
 @mcp.tool()
 def map_module_to_project_type(
     module_path: str,
@@ -284,7 +281,7 @@ def map_module_to_project_type(
 ) -> str:
     """
     Map the module's intent to a control-plane project type by creating/updating the intent type.
-    
+
     Note: Built-in intents cannot be modified. If you need to modify an intent that is built-in,
     you should create a new custom intent with a different name.
 
@@ -294,14 +291,14 @@ def map_module_to_project_type(
         display_name: Optional display name override (defaults to existing)
         description: Optional description override (defaults to existing)
         icon_url: Optional icon URL (only if explicitly provided)
-        
+
     Returns:
         JSON string with success/error information
-        
+
     Example:
         # For a custom intent:
         map_module_to_project_type('/path/to/module', 'custom_type')
-        
+
         # For a built-in intent, you'll need to create a new intent first:
         create_or_update_intent(
             name='my-custom-mongo',
@@ -313,7 +310,11 @@ def map_module_to_project_type(
     ok, intent, err = _read_module_intent(module_path)
     if not ok:
         return json.dumps(
-            {"success": False, "message": err, "instructions": "Inform User: Fix facets.yaml and retry."},
+            {
+                "success": False,
+                "message": err,
+                "instructions": "Inform User: Fix facets.yaml and retry.",
+            },
             indent=2,
         )
 
@@ -336,12 +337,12 @@ def map_module_to_project_type(
                             "error": "Built-in intents cannot be modified",
                             "instructions": (
                                 "This is a built-in intent and cannot be modified.\n"
-                                f"To proceed, you can either:\n"
+                                "To proceed, you can either:\n"
                                 "1. Use the intent as-is without modification\n"
                                 "2. Create a new custom intent using create_or_update_intent()\n"
                                 "3. Use list_all_intents() to see available intents"
                             ),
-                            "is_builtin": True
+                            "is_builtin": True,
                         },
                         indent=2,
                     )
@@ -352,12 +353,18 @@ def map_module_to_project_type(
             name=intent,
             type=project_type,
             display_name=(
-                display_name if display_name is not None else getattr(existing, "display_name", intent)
+                display_name
+                if display_name is not None
+                else getattr(existing, "display_name", intent)
             ),
             description=(
-                description if description is not None else getattr(existing, "description", f"Intent {intent}")
+                description
+                if description is not None
+                else getattr(existing, "description", f"Intent {intent}")
             ),
-            icon_url=icon_url if icon_url is not None else getattr(existing, "icon_url", None),
+            icon_url=icon_url
+            if icon_url is not None
+            else getattr(existing, "icon_url", None),
             inferred_from_module=False,
         )
 
@@ -390,12 +397,12 @@ def map_module_to_project_type(
                     "error": error_msg,
                     "instructions": (
                         "This is a built-in intent and cannot be modified.\n"
-                        f"To proceed, you can either:\n"
+                        "To proceed, you can either:\n"
                         "1. Use the intent as-is without modification\n"
                         "2. Create a new custom intent using create_or_update_intent()\n"
                         "3. Use list_all_intents() to see available intents"
                     ),
-                    "is_builtin": True
+                    "is_builtin": True,
                 },
                 indent=2,
             )
@@ -410,8 +417,10 @@ def map_module_to_project_type(
         )
     except Exception as e:
         return json.dumps(
-            {"success": False, "message": "Error mapping project type.", "error": str(e)},
+            {
+                "success": False,
+                "message": "Error mapping project type.",
+                "error": str(e),
+            },
             indent=2,
         )
-
-    

--- a/facets_mcp/tools/intent_management_tools.py
+++ b/facets_mcp/tools/intent_management_tools.py
@@ -360,11 +360,9 @@ def map_module_to_project_type(
             description=(
                 description
                 if description is not None
-                else getattr(existing, "description", f"Intent {intent}")
+                else getattr(existing, "description", f"Intent '{intent}'")
             ),
-            icon_url=icon_url
-            if icon_url is not None
-            else getattr(existing, "icon_url", None),
+            icon_url=icon_url,  # Only use explicitly provided icon_url
             inferred_from_module=False,
         )
 

--- a/facets_mcp/utils/intent_utils.py
+++ b/facets_mcp/utils/intent_utils.py
@@ -12,7 +12,10 @@ def check_intent_and_intent_details(module_path: str) -> tuple[bool, str]:
     Checks if the intent in facets.yaml exists in the control plane. If not, checks for presence of intentDetails.
     Returns (success, message). If not success, message contains user instructions and suggestions.
     """
-    facets_path = os.path.join(os.path.abspath(module_path), "facets.yaml")
+    abs_path = os.path.abspath(module_path)
+    if not os.path.isdir(abs_path):
+        return False, f"Module path '{module_path}' is not a valid directory."
+    facets_path = os.path.join(abs_path, "facets.yaml")
     if not os.path.exists(facets_path):
         return False, "facets.yaml not found in module path."
 

--- a/facets_mcp/utils/yaml_utils.py
+++ b/facets_mcp/utils/yaml_utils.py
@@ -30,7 +30,10 @@ def validate_yaml(module_path: str, yaml_content: str) -> None:
     """
     import os
 
-    temp_path = os.path.join(os.path.abspath(module_path), "facets.yaml.new")
+    abs_path = os.path.abspath(module_path)
+    if not os.path.isdir(abs_path):
+        raise RuntimeError(f"Module path '{module_path}' is not a valid directory.")
+    temp_path = os.path.join(abs_path, "facets.yaml.new")
     try:
         with open(temp_path, "w") as temp_file:
             temp_file.write(yaml_content)
@@ -245,7 +248,14 @@ def read_and_validate_facets_yaml(
             - error_message: An error message if there was a problem, empty string otherwise
     """
     # Check if facets.yaml exists in the module path
-    facets_path = os.path.join(os.path.abspath(module_path), "facets.yaml")
+    abs_path = os.path.abspath(module_path)
+    if not os.path.isdir(abs_path):
+        return (
+            False,
+            "",
+            f"Module path '{module_path}' is not a valid directory.",
+        )
+    facets_path = os.path.join(abs_path, "facets.yaml")
     if not os.path.exists(facets_path):
         return (
             False,


### PR DESCRIPTION
## Changes
1. Added [map_module_to_project_type](cci:1://file:///Users/satyendragolla/facets-repos/facets-module-mcp/facets_mcp/tools/intent_management_tools.py:276:0-414:9) tool in [intent_management_tools.py](cci:7://file:///Users/satyendragolla/facets-repos/facets-module-mcp/facets_mcp/tools/intent_management_tools.py:0:0-0:0):
   - Handles mapping between module intents and project types
   - Includes proper validation for built-in intents
   - Provides clear error messages and guidance

2. Added new [publish_module_to_facets_cp](cci:1://file:///Users/satyendragolla/facets-repos/facets-module-mcp/facets_mcp/tools/ftf_tools.py:119:0-236:9) tool in [ftf_tools.py](cci:7://file:///Users/satyendragolla/facets-repos/facets-module-mcp/facets_mcp/tools/ftf_tools.py:0:0-0:0):
   - Handles module publishing to Facets control plane
   - Includes fallback mechanisms for different FTF CLI versions
   - Provides clear error handling and user feedback

3. Modified [push_preview_module_to_facets_cp](cci:1://file:///Users/satyendragolla/facets-repos/facets-module-mcp/facets_mcp/tools/ftf_tools.py:556:0-624:9):
   - Removed `publishable` flag as it's no longer needed
   - Simplified the preview module workflow
   - Maintained backward compatibility

## Testing
- [ ] Verified intent mapping works with custom intents
- [x] Confirmed proper error handling for built-in intents
- [x] Tested module publishing workflow
- [x] Verified preview module push works as expected

## Notes
- Built-in intents are now properly protected from modification
- Users receive clear guidance when working with built-in intents
- The code includes comprehensive error handling and user feedback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Production module publish workflow with intent validation and structured success/error reporting
  * Module-to-project-type mapping tool that reads module manifest intent/flavor and creates/updates project type entries

* **Enhancements**
  * Preview flow now treats previews as publishable by default and always includes Git metadata
  * Stronger module-path and manifest YAML validation with clearer error messages
  * Intent creation refined to include optional icon only when provided
<!-- end of auto-generated comment: release notes by coderabbit.ai -->