### PR TITLE
Fix write_outputs to always generate empty blocks for attributes and interfaces

### DIFF
--- a/facets_mcp/tools/module_files.py
+++ b/facets_mcp/tools/module_files.py
@@ -648,9 +648,9 @@ def write_outputs(
         # Helper to build terraform block for a field set
         def build_terraform_block(block_name, validated_fields, sensitive_fields):
             """Build terraform configuration block for output fields."""
-            lines = []
+            lines = [f"  {block_name} = {{"]
+
             if validated_fields:
-                lines.append(f"  {block_name} = {{")
                 for k, field_model in validated_fields.items():
                     rendered_value = render_terraform_value(field_model.value)
                     if field_model.sensitive:
@@ -667,7 +667,7 @@ def write_outputs(
                     )
                     lines.append(f"    secrets = {secrets_str}")
 
-                lines.append("  }")
+            lines.append("  }")
             return lines
 
         # Build outputs.tf content


### PR DESCRIPTION
## Summary
- Fixed `write_outputs` function to always include both `output_attributes` and `output_interfaces` blocks in generated `outputs.tf` files
- Previously, empty blocks were omitted entirely; now they're rendered as empty blocks for consistency

## Problem
When calling `write_outputs` with only `output_attributes` (no interfaces) or vice versa, the empty block would be completely omitted from the generated `outputs.tf` file. This led to inconsistent file structure across modules.

## Solution
Modified the `build_terraform_block` helper function in `write_outputs`:
- Opening brace is now always added before checking for fields
- Closing brace is now always added after the conditional block
- Empty blocks now render as: `block_name = {}`

## Example
**Before:** (with only attributes, no interfaces)
```hcl
locals {
  output_attributes = {
    instance_id = aws_instance.example.id
  }
}
```

**After:** (both blocks always present)
```hcl
locals {
  output_attributes = {
    instance_id = aws_instance.example.id
  }
  output_interfaces = {
  }
}
```

## Test plan
- [ ] Test `write_outputs` with only `output_attributes` - verify `output_interfaces = {}` is present
- [ ] Test `write_outputs` with only `output_interfaces` - verify `output_attributes = {}` is present
- [ ] Test `write_outputs` with both populated - verify both blocks render correctly
- [ ] Test `write_outputs` with both empty - verify both empty blocks are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the internal structure of terraform value rendering to improve code clarity and eliminate redundant operations. No changes to output formatting or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->