### PR TITLE
feat: Add multi-cloud support to generate_module_with_user_confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This MCP (Model Context Protocol) Server for the Facets Module assists in creati
 | `write_outputs`                          | Writes the `outputs.tf` file for a module with output attributes and interfaces in a local block.                                       |
 | `write_readme_file`                      | Writes a `README.md` file for the module directory with AI-generated content.                                                           |
 | `write_generic_file`                     | Writes files generically with working directory and file type checks. Path: `facets_mcp/tools/module_files.py`                            |
-| `generate_module_with_user_confirmation` | Generates a new Terraform module scaffold with dry-run preview and user confirmation.                                                    |
+| `generate_module_with_user_confirmation` | Generates a new Terraform module scaffold with dry-run preview and user confirmation. Supports single or multiple cloud providers (comma-separated). |
 | `validate_module`                        | Validates a Terraform module directory using FTF CLI standards and checks output types.                                                 |
 | `push_preview_module_to_facets_cp`       | Previews a module by pushing a test version to the control plane with git context extracted automatically.                             |
 | `register_output_type`                   | Registers a new output type in the Facets control plane with interfaces and attributes and providers.                                                  |

--- a/facets_mcp/tools/ftf_tools.py
+++ b/facets_mcp/tools/ftf_tools.py
@@ -68,7 +68,7 @@ def generate_module_with_user_confirmation(
     ⚠️ IMPORTANT: REQUIRES USER CONFIRMATION ⚠️
     This function performs an irreversible action
 
-    Tool to generate a new module using FTF CLI.
+    Tool to generate a new module using FTF CLI with support for multiple cloud providers.
     Step 1 - ALWAYS use dry_run=True first. This is an irreversible action.
     Step 2 - Present the dry run output to the user in textual format.
     Step 3 - Ask if user will like to make any changes in passed arguments and modify them
@@ -77,20 +77,32 @@ def generate_module_with_user_confirmation(
     Args:
     - intent (str): The intent for the module.
     - flavor (str): The flavor of the module.
-    - cloud (str): The cloud provider.
+    - cloud (str): The cloud provider(s). Supports multiple clouds as comma-separated values.
+                   Examples:
+                   - Single cloud: "aws"
+                   - Multiple clouds: "aws,gcp,azure" or "aws, gcp, azure" (whitespace is handled)
     - title (str): The title of the module.
     - description (str): The description of the module.
     - dry_run (bool): If True, returns a description of the generation without executing. MUST set to True initially.
 
     Returns:
     - str: A JSON string with the output from the FTF command execution.
+
+    Examples:
+    - Single cloud: cloud="aws" → clouds: ['aws']
+    - Multiple clouds: cloud="aws,gcp,azure" → clouds: ['aws', 'gcp', 'azure']
+    - With spaces: cloud="aws, gcp , azure" → clouds: ['aws', 'gcp', 'azure']
     """
+    # Parse clouds list from comma-separated input
+    clouds_list = [c.strip() for c in cloud.split(",")]
+
     if dry_run:
         return json.dumps(
             {
                 "success": True,
                 "message": (
-                    f"Dry run: The following module will be generated with intent='{intent}', flavor='{flavor}', cloud='{cloud}', title='{title}', description='{description}'. "
+                    f"Dry run: The following module will be generated with intent='{intent}', flavor='{flavor}', "
+                    f"cloud(s)={clouds_list}, title='{title}', description='{description}'. "
                     f"Get confirmation from the user before running with dry_run=False to execute the generation."
                 ),
                 "instructions": (
@@ -101,6 +113,7 @@ def generate_module_with_user_confirmation(
                     "intent": intent,
                     "flavor": flavor,
                     "cloud": cloud,
+                    "clouds": clouds_list,
                     "title": title,
                     "description": description,
                 },
@@ -130,7 +143,7 @@ def generate_module_with_user_confirmation(
             {
                 "success": True,
                 "message": "Module generation successful.",
-                "data": {"output": output},
+                "data": {"output": output, "clouds": clouds_list},
             },
             indent=2,
         )

--- a/facets_mcp/tools/module_instructions/generation_workflow.md
+++ b/facets_mcp/tools/module_instructions/generation_workflow.md
@@ -29,7 +29,7 @@ From the user's answer, extract or clarify the following fields:
 |-----------------|-------------------------------------------------------------|------------------------------------------------------------------------|
 | **Intent**      | The abstract capability (e.g., `gcp-databricks-cluster`)    | "What should be the intent name for this module?"                      |
 | **Flavor**      | A specific variant (e.g., `secure-access`, `ha`)            | "Is there a flavor or variant you want to capture in the module name?" |
-| **Cloud**       | Target cloud provider (`gcp`, `aws`, `azure`)               | "Which cloud provider is this for?"                                    |
+| **Cloud**       | Target cloud provider(s). Supports single or multiple clouds (comma-separated).<br>Examples: `aws`, `gcp`, `aws,gcp,azure`, `aws, gcp, azure` | "Which cloud provider(s) is this for?"                                    |
 | **Title**       | Display name for UI (e.g., "Secure GCP Databricks Cluster") | "What's a user-friendly title for this module?"                        |
 | **Description** | One-liner describing what this module does                  | "Describe this module in a sentence or two"                            |
 


### PR DESCRIPTION
## Summary
This PR adds support for multiple cloud providers to the `generate_module_with_user_confirmation` tool, aligning with the FTF CLI updates that now support comma-separated cloud values.

## Changes Made

### 1. Updated `facets_mcp/tools/ftf_tools.py`
- Enhanced `generate_module_with_user_confirmation` function to parse comma-separated cloud values
- Added cloud list parsing: `clouds_list = [c.strip() for c in cloud.split(",")]`
- Updated docstring with comprehensive examples and multi-cloud documentation
- Added `clouds` field to response data (both dry_run and success responses)
- Maintains full backward compatibility with single cloud input

### 2. Updated `facets_mcp/tools/module_instructions/generation_workflow.md`
- Updated Cloud field description in metadata table
- Added examples: `aws`, `gcp`, `aws,gcp,azure`, `aws, gcp, azure`
- Changed prompt to "Which cloud provider(s) is this for?"

### 3. Updated `README.md`
- Updated tool description to mention multi-cloud support
- Added note: "Supports single or multiple cloud providers (comma-separated)"

## Test Results

✅ **Single cloud**: `cloud="aws"` → `clouds: ['aws']`  
✅ **Multiple clouds**: `cloud="aws,gcp,azure"` → `clouds: ['aws', 'gcp', 'azure']`  
✅ **With spaces**: `cloud="aws, gcp , azure"` → `clouds: ['aws', 'gcp', 'azure']`

## Implementation Details

- **Backward Compatibility**: Existing single cloud usage continues to work without any changes
- **Whitespace Handling**: The parser strips whitespace from each cloud provider name
- **FTF CLI Integration**: The cloud parameter is passed directly to FTF CLI which handles the actual processing
- **Response Enhancement**: Both dry_run preview and success responses now include the parsed `clouds` list

## Example Usage

### Single Cloud (backward compatible)
```python
generate_module_with_user_confirmation(
    intent="s3-bucket",
    flavor="secure",
    cloud="aws",
    title="Secure S3 Bucket",
    description="S3 bucket with encryption"
)
```

### Multiple Clouds (new feature)
```python
generate_module_with_user_confirmation(
    intent="kubernetes-cluster",
    flavor="ha",
    cloud="aws,gcp,azure",
    title="Multi-Cloud K8s Cluster",
    description="HA Kubernetes cluster"
)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud provider selection now supports multiple providers via comma-separated input.

* **Documentation**
  * Updated documentation with examples and guidance for configuring single or multiple cloud providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->